### PR TITLE
Dotnetcore/get legacy working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ ipch/
 *.vsp
 *.vspx
 
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
 # TFS 2012 Local Workspace
 $tf/
 

--- a/Source/Gep13.Sample.Api/Gep13.Sample.Api.csproj
+++ b/Source/Gep13.Sample.Api/Gep13.Sample.Api.csproj
@@ -22,6 +22,8 @@
     <IISExpressUseClassicPipelineMode />
     <NuGetPackageImportStamp>f0f7076e</NuGetPackageImportStamp>
     <BuildToolsFxCopVersion>1.0.1</BuildToolsFxCopVersion>
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +58,9 @@
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Autofac.Integration.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.Owin.3.1.0\lib\net45\Autofac.Integration.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Autofac.Integration.WebApi, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Gep13.Sample.Api/Startup.cs
+++ b/Source/Gep13.Sample.Api/Startup.cs
@@ -7,7 +7,14 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Reflection;
+using System.Web.Http;
+
+using Autofac.Integration.WebApi;
+using Gep13.Sample.Api.Mappers;
+using Gep13.Sample.Common;
 using Microsoft.Owin;
+using Microsoft.Owin.Security.OAuth;
 using Owin;
 
 [assembly: OwinStartup(typeof(Gep13.Sample.Api.Startup))]
@@ -22,6 +29,35 @@ namespace Gep13.Sample.Api
         public static void Configuration(IAppBuilder app)
         {
             ConfigureAuth(app);
+
+            var config = new HttpConfiguration();
+            config.EnableCors();
+
+            // Web API configuration and services
+            // Configure Web API to use only bearer token authentication.
+            config.SuppressDefaultHostAuthentication();
+            config.Filters.Add(new HostAuthenticationFilter(OAuthDefaults.AuthenticationType));
+
+            //// config.Filters.Add(new AuthorizeAttribute());
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute("DefaultApi", "api/{controller}/{id}", new { id = RouteParameter.Optional });
+
+            var containerBuilder = AutofacBootstrapper.Configure();
+
+            containerBuilder.RegisterApiControllers(Assembly.Load("Gep13.Sample.Api"));
+
+            var container = containerBuilder.Build();
+
+            config.DependencyResolver = new AutofacWebApiDependencyResolver(container);
+
+            AutoMapperConfiguration.Configure();
+
+            app.UseAutofacMiddleware(container);
+
+            app.UseWebApi(config);
         }
     }
 }

--- a/Source/Gep13.Sample.Api/packages.config
+++ b/Source/Gep13.Sample.Api/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net451" />
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="Autofac.Owin" version="3.1.0" targetFramework="net451" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net451" />
   <package id="AutoMapper" version="3.3.0-ci1008" targetFramework="net451" />
   <package id="BuildTools.FxCop" version="1.0.1" targetFramework="net451" />

--- a/Tests/Gep13.Sample.Api.IntegrationTests/Gep13.Sample.Api.IntegrationTests.csproj
+++ b/Tests/Gep13.Sample.Api.IntegrationTests/Gep13.Sample.Api.IntegrationTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props" Condition="Exists('..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>Gep13.Sample.Api.IntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -177,6 +180,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Source\packages\AutoMapper.3.3.0-ci1008\tools\AutoMapper.targets" Condition="Exists('..\..\Source\packages\AutoMapper.3.3.0-ci1008\tools\AutoMapper.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/Gep13.Sample.Api.IntegrationTests/packages.config
+++ b/Tests/Gep13.Sample.Api.IntegrationTests/packages.config
@@ -24,5 +24,6 @@
   <package id="Microsoft.Owin.Testing" version="3.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net451" />
   <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnitTestAdapter" version="2.2.0" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
 </packages>

--- a/Tests/Gep13.Sample.Service.Tests/Gep13.Sample.Service.Tests.csproj
+++ b/Tests/Gep13.Sample.Service.Tests/Gep13.Sample.Service.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props" Condition="Exists('..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -90,6 +93,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Source\packages\AutoMapper.3.3.0-ci1008\tools\AutoMapper.targets" Condition="Exists('..\..\Source\packages\AutoMapper.3.3.0-ci1008\tools\AutoMapper.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Source\packages\NUnitTestAdapter.2.2.0\build\NUnitTestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/Gep13.Sample.Service.Tests/packages.config
+++ b/Tests/Gep13.Sample.Service.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="AutoMapper" version="3.3.0-ci1008" targetFramework="net451" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net451" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.2.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Changes to get the existing app to run, without any changes to the .Net framework being used.

I assume the existing code was not updated to run correctly, so this would be the new baseline to use for our example.